### PR TITLE
Fix slug context for post pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -49,7 +49,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       path: node.frontmatter.slug,
       component: postTemplate,
       context: {
-        path: node.frontmatter.slug,
+        slug: node.frontmatter.slug,
       },
     });
   });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -48,7 +48,9 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     createPage({
       path: node.frontmatter.slug,
       component: postTemplate,
-      context: {},
+      context: {
+        path: node.frontmatter.slug,
+      },
     });
   });
 

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -99,8 +99,8 @@ PostTemplate.propTypes = {
 };
 
 export const pageQuery = graphql`
-  query($path: String!) {
-    markdownRemark(frontmatter: { slug: { eq: $path } }) {
+  query($slug: String!) {
+    markdownRemark(frontmatter: { slug: { eq: $slug } }) {
       html
       frontmatter {
         title


### PR DESCRIPTION
## Summary
- fix missing `path` context when creating post pages

## Testing
- `node -c gatsby-node.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844643547f48322ad9effb56f18dbed