### PR TITLE
Fix grammar in docker-compose post

### DIFF
--- a/content/posts/docker-compose-error/index.md
+++ b/content/posts/docker-compose-error/index.md
@@ -28,7 +28,7 @@ The error was coming from the `-w` flag in the `docker-compose exec` command in 
 
 ## Solution
 
-Turns The fix was to update the version in my `docker-compose.yml` file to from version `3.5` to `3.6`. It's strange because 3.5 isn't anywhere close to the API version `1.35` from the error message 🤷‍♀️
+Turns out the fix was to update the version in my `docker-compose.yml` file from `3.5` to `3.6`. It's strange because 3.5 isn't anywhere close to the API version `1.35` from the error message 🤷‍♀️
 
 ```yaml:title=docker-compose.yml
 version: '3.6' # highlight-line


### PR DESCRIPTION
## Summary
- correct grammar in Docker Compose error post

## Testing
- `npm run format` *(fails: Cannot find module '@upstatement/prettier-config')*

------
https://chatgpt.com/codex/tasks/task_e_6844652235ac8322bd3415ebd7f035fe